### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "git clone https://github.com/harshjv/threes-c.git && cd threes-c && make run"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Threes C! [![Build Status](https://travis-ci.org/harshjv/threes-c.svg)](https://travis-ci.org/harshjv/threes-c)
 
+[![Run on Repl.it](https://repl.it/badge/github/harshjv/threes-c)](https://repl.it/github/harshjv/threes-c)
+
 Threes C is a port of [Threes!](http://www.threesgame.com) game to C.
+
 
 
 ## Play!


### PR DESCRIPTION
Saw this and found that it was really easy to configure to run in-browser through Repl.it. I think this would be a fun addition!

![Capture](https://user-images.githubusercontent.com/39810066/70536154-37fc1600-1b2c-11ea-8fc8-298ec6ac27a2.PNG)

_"This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/threes-c)."_